### PR TITLE
Introduce `within` scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Transaction.paid_from("2017-09-06") # => where("paid_at >= '2017-09-06'")
 Transaction.paid_after("2017-09-06") # => where("paid_at > '2017-09-06'")
 Transaction.paid_before("2017-09-06") #= where("paid_at < '2017-09-06'")
 Transaction.paid_between("2017-09-06", "2017-09-07")  # => where("paid_at BETWEEN '2017-09-06' AND '2017-09-07'")
-Transaction.paid_within("2017-09-06", "2017-09-07")  # => where("paid_at >= '2017-09-06' AND paid_at < '2017-09-07'")
+Transaction.paid_within("2017-09-06", "2017-09-07")  # => where("paid_at > '2017-09-06' AND paid_at < '2017-09-07'")
 
 # Numeric scopes
 Transaction.amount_to(100) # => where("amount <= 100")
@@ -27,7 +27,7 @@ Transaction.amount_from(100) # => where("amount >= 100")
 Transaction.amount_above(100) # => where("amount > 100")
 Transaction.amount_below(100) # => where("amount < 100")
 Transaction.amount_between(100, 200) # => where("amount BETWEEN 100 AND 200")
-Transaction.amount_within(100, 200) # => where("amount >= 100 AND amount < 200")
+Transaction.amount_within(100, 200) # => where("amount > 100 AND amount < 200")
 
 # String scopes
 Transaction.description_contains("foo") # => where("description LIKE '%foo%'")

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Type scopes creates useful scopes based on the type of the columns of your models.
 It handles dates, times, strings and numerics.
 
-Here is an example of all the available scopes:
+Here are examples for all the available scopes:
 
 ```ruby
 # paid_at: datetime
@@ -19,6 +19,7 @@ Transaction.paid_from("2017-09-06") # => where("paid_at >= '2017-09-06'")
 Transaction.paid_after("2017-09-06") # => where("paid_at > '2017-09-06'")
 Transaction.paid_before("2017-09-06") #= where("paid_at < '2017-09-06'")
 Transaction.paid_between("2017-09-06", "2017-09-07")  # => where("paid_at BETWEEN '2017-09-06' AND '2017-09-07'")
+Transaction.paid_within("2017-09-06", "2017-09-07")  # => where("paid_at >= '2017-09-06' AND paid_at < '2017-09-07'")
 
 # Numeric scopes
 Transaction.amount_to(100) # => where("amount <= 100")
@@ -26,6 +27,7 @@ Transaction.amount_from(100) # => where("amount >= 100")
 Transaction.amount_above(100) # => where("amount > 100")
 Transaction.amount_below(100) # => where("amount < 100")
 Transaction.amount_between(100, 200) # => where("amount BETWEEN 100 AND 200")
+Transaction.amount_within(100, 200) # => where("amount >= 100 AND amount < 200")
 
 # String scopes
 Transaction.description_contains("foo") # => where("description LIKE '%foo%'")

--- a/lib/numeric_scopes.rb
+++ b/lib/numeric_scopes.rb
@@ -21,6 +21,7 @@ module NumericScopes
       scope :"#{name}_above", lambda { |value| where("#{quoted_table_name}.#{name} > ?", value) }
       scope :"#{name}_below", lambda { |value| where("#{quoted_table_name}.#{name} < ?", value) }
       scope :"#{name}_between", lambda { |from, to| where("#{quoted_table_name}.#{name} BETWEEN ? AND ?", from, to) }
+      scope :"#{name}_within", lambda { |from, to| where("#{quoted_table_name}.#{name} >= ? AND #{quoted_table_name}.#{name} < ?", from, to) }
     end
   end
 end

--- a/lib/numeric_scopes.rb
+++ b/lib/numeric_scopes.rb
@@ -21,7 +21,7 @@ module NumericScopes
       scope :"#{name}_above", lambda { |value| where("#{quoted_table_name}.#{name} > ?", value) }
       scope :"#{name}_below", lambda { |value| where("#{quoted_table_name}.#{name} < ?", value) }
       scope :"#{name}_between", lambda { |from, to| where("#{quoted_table_name}.#{name} BETWEEN ? AND ?", from, to) }
-      scope :"#{name}_within", lambda { |from, to| where("#{quoted_table_name}.#{name} >= ? AND #{quoted_table_name}.#{name} < ?", from, to) }
+      scope :"#{name}_within", lambda { |from, to| where("#{quoted_table_name}.#{name} > ? AND #{quoted_table_name}.#{name} < ?", from, to) }
     end
   end
 end

--- a/lib/timestamp_scopes.rb
+++ b/lib/timestamp_scopes.rb
@@ -22,7 +22,7 @@ module TimestampScopes
       scope :"#{short_name}_after", lambda { |date| where("#{quoted_table_name}.#{name} > ?", date) }
       scope :"#{short_name}_before", lambda { |date| where("#{quoted_table_name}.#{name} < ?", date) }
       scope :"#{short_name}_between", lambda { |from, to| where("#{quoted_table_name}.#{name} BETWEEN ? AND ?", from, to) }
-      scope :"#{short_name}_within", lambda { |from, to| where("#{quoted_table_name}.#{name} >= ? AND #{quoted_table_name}.#{name} < ?", from, to) }
+      scope :"#{short_name}_within", lambda { |from, to| where("#{quoted_table_name}.#{name} > ? AND #{quoted_table_name}.#{name} < ?", from, to) }
     end
 
     def shorten_column_name(name)

--- a/lib/timestamp_scopes.rb
+++ b/lib/timestamp_scopes.rb
@@ -22,6 +22,7 @@ module TimestampScopes
       scope :"#{short_name}_after", lambda { |date| where("#{quoted_table_name}.#{name} > ?", date) }
       scope :"#{short_name}_before", lambda { |date| where("#{quoted_table_name}.#{name} < ?", date) }
       scope :"#{short_name}_between", lambda { |from, to| where("#{quoted_table_name}.#{name} BETWEEN ? AND ?", from, to) }
+      scope :"#{short_name}_within", lambda { |from, to| where("#{quoted_table_name}.#{name} >= ? AND #{quoted_table_name}.#{name} < ?", from, to) }
     end
 
     def shorten_column_name(name)


### PR DESCRIPTION
Hey there!

Thanks for creating this wonderful and handy gem!

This PR introduces a `within` scope for numeric and date types.

While `between` is an inclusive range `within` is an exclusive range which could come in handy in some situations.

```ruby
Transaction.paid_within("2017-09-06", "2017-09-07") 
# => where("paid_at > '2017-09-06' AND paid_at < '2017-09-07'")

Transaction.amount_within(100, 200)
# => where("amount > 100 AND amount < 200")
```

I'm not sure if `within` is the best name for this, if you have a better idea let me know.